### PR TITLE
APISink and Extending SeqSink

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,6 +188,7 @@ const logger2 = new LoggerConfiguration()
 |[ConsoleSink](#console-sink)|Outputs events through the `console` object in Node or the browser.|
 |[ColoredConsoleSink](#colored-console-sink)|Outputs the same as **ConsoleSink** but with **Colors**.|
 |[SeqSink](#seq-sink)|Outputs events to a Seq server|
+|[APISink](#api-sink)|Outputs events to a custom API|
 
 ### Filtering
 
@@ -356,6 +357,55 @@ It supports the following properties:
 |`levelSwitch`|DynamicLevelSwitch which the Seq log level will control and use|&#x2717;|
 |`suppressErrors`|If true, errors in the pipeline will be suppressed and logged to the console instead (defaults to true)|&#x2717;|
 |`url`|URL to the Seq server|&#x2713;|
+
+Or, if you need to develop a custom sink and using ES6 or TypeScript, you can use it as a base class to add any custom behaviors :
+
+```js
+class MySink extends SeqSink {
+  constructor() {
+    // ...
+    super(options: SeqSinkOptions);
+    // ...
+  }
+
+  // Override postToLogger to add your own sink's behavior, and optionally toString
+
+  public toString() {
+    return 'MySink';
+  }
+
+  protected postToLogger(url: any, apiKey: any, compact: boolean, body: any) {
+    // ...
+    const promise = fetch(`${url}`, {
+      // ...
+    });
+    return promise;
+   }
+}
+```
+
+### API Sink
+
+The `APISink` outputs events to a custom POST API with the option of custom headers along the request. It can be used like any of the other sinks.
+
+```js
+.writeTo(new SeqSink({
+  url: "http://localhost:5341/api/log/custom",
+  headers: {"header1": "value1"}
+}))
+```
+
+The `options` parameter is required, however the only required property is the `url`.
+It supports the following properties:
+
+|Key|Description|Required?|
+|---|---|---|
+|`compact`|If true, events be serialized using Serilog's compact format|&#x2717;|
+|`durable`|If true, events will be buffered in local storage if available|&#x2717;|
+|`levelSwitch`|DynamicLevelSwitch which the Seq log level will control and use|&#x2717;|
+|`suppressErrors`|If true, errors in the pipeline will be suppressed and logged to the console instead (defaults to true)|&#x2717;|
+|`url`|URL to the API|&#x2713;|
+|`headers`|Any headers required to be sent with the request|&#x2713;|
 
 ## Child Logger Functionality
 

--- a/src/APISink.ts
+++ b/src/APISink.ts
@@ -1,0 +1,74 @@
+import { DynamicLevelSwitch } from './dynamicLevelSwitch';
+import { SeqSink } from './seqSink';
+
+export interface APISinkOptions {
+    /**
+     * If true, events be serialized using Serilog's compact format
+     */
+    compact?: boolean;
+
+    /**
+     * If true, events will be buffered in local storage if available
+     */
+    durable?: boolean;
+
+    /**
+     * DynamicLevelSwitch which the Seq log level will control and use
+     */
+    levelSwitch?: DynamicLevelSwitch;
+
+    /**
+     * If true, errors in the pipeline will be suppressed and logged to the console instead (defaults to true)
+     */
+    suppressErrors?: boolean;
+
+    /**
+     * URL of the API
+     */
+    url: string;
+
+    /**
+     * Custom headers to be sent with the request
+     */
+    headers: {[key: string]: string};
+}
+
+export class APISink extends SeqSink {
+    headers: {[key: string]: string} = null;
+
+    constructor(options: APISinkOptions) {
+        let seqOptions = {
+            apiKey: "",
+            compact: options.compact,
+            durable: options.durable,
+            levelSwitch: options.levelSwitch,
+            suppressErrors: options.suppressErrors,
+            url: options.url
+        };
+        super(seqOptions);
+
+        if (this.headers !== null) {
+            this.headers = options.headers;
+        }
+    }
+
+    public toString() {
+        return 'APISink';
+    }
+
+    protected postToLogger(url: any, apiKey: any, compact: boolean, body: any) {
+        const promise = fetch(`${url}`, {
+            headers: this.headers || {},
+            method: 'POST',
+            body
+        });
+
+        return promise;
+    }
+
+    protected logSuppressedError(reason: string) {
+        if (typeof console !== 'undefined' && console.warn) {
+            console.warn('Suppressed error when logging to API: ' + reason);
+        }
+    }
+}

--- a/src/APISink.ts
+++ b/src/APISink.ts
@@ -30,7 +30,7 @@ export interface APISinkOptions {
     /**
      * Custom headers to be sent with the request
      */
-    headers: {[key: string]: string};
+    headers?: {[key: string]: string};
 }
 
 export class APISink extends SeqSink {
@@ -39,10 +39,10 @@ export class APISink extends SeqSink {
     constructor(options: APISinkOptions) {
         let seqOptions = {
             apiKey: "",
-            compact: options.compact,
-            durable: options.durable,
+            compact: options.compact || false,
+            durable: options.durable || false,
             levelSwitch: options.levelSwitch,
-            suppressErrors: options.suppressErrors,
+            suppressErrors: options.suppressErrors || true,
             url: options.url
         };
         super(seqOptions);

--- a/src/APISink.ts
+++ b/src/APISink.ts
@@ -65,10 +65,4 @@ export class APISink extends SeqSink {
 
         return promise;
     }
-
-    protected logSuppressedError(reason: string) {
-        if (typeof console !== 'undefined' && console.warn) {
-            console.warn('Suppressed error when logging to API: ' + reason);
-        }
-    }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,7 @@ export { ColoredConsoleSink } from './coloredConsoleSink';
 export { BatchedSink, BatchedSinkOptions } from './batchedSink';
 export { DynamicLevelSwitch } from './dynamicLevelSwitch';
 export { SeqSink, SeqSinkOptions } from './seqSink';
+export { APISink, APISinkOptions } from './apiSink';
 export { Sink } from './sink';
 
 import { LoggerConfiguration } from './loggerConfiguration';

--- a/src/seqSink.ts
+++ b/src/seqSink.ts
@@ -203,9 +203,9 @@ export class SeqSink implements Sink {
         return promise;
     }
 
-    protected logSuppressedError(reason: string) {
+    private logSuppressedError(reason: string) {
         if (typeof console !== 'undefined' && console.warn) {
-            console.warn('Suppressed error when logging to Seq: ' + reason);
+            console.warn('Suppressed error when logging to ' + this.toString() + ': ' + reason);
         }
     }
 

--- a/src/seqSink.ts
+++ b/src/seqSink.ts
@@ -72,12 +72,12 @@ export class SeqSink implements Sink {
             const requests = {};
             for (let i = 0; i < localStorage.length; ++i) {
                 const storageKey = localStorage.key(i);
-                if (storageKey.indexOf('serilogger-seq-sink') !== 0) {
+                if (storageKey.indexOf('serilogger-' + this.toString()) !== 0) {
                     continue;
                 }
 
                 const body = localStorage.getItem(storageKey);
-                requests[storageKey] = this.postToSeq(this.url, this.apiKey, this.compact, body)
+                requests[storageKey] = this.postToLogger(this.url, this.apiKey, this.compact, body)
                     .then(() => localStorage.removeItem(storageKey))
                     .catch(reason => {
                         if (this.suppressErrors) this.logSuppressedError(reason); 
@@ -142,12 +142,12 @@ export class SeqSink implements Sink {
 
         let storageKey: string;
         if (this.durable) {
-            storageKey = `serilogger-seq-sink-${new Date().getTime()}-${Math.floor(Math.random() * 1000000) + 1}`;
+            storageKey = `serilogger-${this.toString()}-${new Date().getTime()}-${Math.floor(Math.random() * 1000000) + 1}`;
             localStorage.setItem(storageKey, body);
         }
 
         try {
-            const response = await this.postToSeq(this.url, this.apiKey, this.compact, body);
+            const response = await this.postToLogger(this.url, this.apiKey, this.compact, body);
             const json = await response.json();
             this.updateLogLevel(json);
             if (storageKey)
@@ -190,7 +190,7 @@ export class SeqSink implements Sink {
         }
     }
 
-    private postToSeq(url: any, apiKey: any, compact: boolean, body: any) {
+    protected postToLogger(url: any, apiKey: any, compact: boolean, body: any) {
         const apiKeyParameter = apiKey ? `?apiKey=${apiKey}` : '';
         const promise = fetch(`${url}/api/events/raw${apiKeyParameter}`, {
             headers: {
@@ -203,7 +203,7 @@ export class SeqSink implements Sink {
         return promise;
     }
 
-    private logSuppressedError(reason: string) {
+    protected logSuppressedError(reason: string) {
         if (typeof console !== 'undefined' && console.warn) {
             console.warn('Suppressed error when logging to Seq: ' + reason);
         }

--- a/test/apiSink.spec.ts
+++ b/test/apiSink.spec.ts
@@ -1,0 +1,18 @@
+// <reference path="../node_modules/@types/node/index.d.ts" />
+/// <reference path="../node_modules/@types/jest/index.d.ts" />
+/// <reference path="../node_modules/typemoq/dist/typemoq.d.ts" />
+
+import {expect} from 'chai';
+import {APISink} from '../src/apiSink';
+
+
+describe('APISink', () => {
+    it('should throw if options are missing', () => {
+        expect(() => new APISink(null)).to.throw();
+    });
+
+    it('should strip trailing slash from the provided URL', () => {
+        const sink = new APISink({url: 'https://test/'});
+        expect(sink.url).to.equal('https://test');
+    })
+});

--- a/test/apiSink.spec.ts
+++ b/test/apiSink.spec.ts
@@ -1,6 +1,6 @@
 // <reference path="../node_modules/@types/node/index.d.ts" />
-/// <reference path="../node_modules/@types/jest/index.d.ts" />
-/// <reference path="../node_modules/typemoq/dist/typemoq.d.ts" />
+// <reference path="../node_modules/@types/jest/index.d.ts" />
+// <reference path="../node_modules/typemoq/dist/typemoq.d.ts" />
 
 import {expect} from 'chai';
 import {APISink} from '../src/apiSink';


### PR DESCRIPTION
Renaming postToSeq to be postToLogger and refactoring. Also, making it protected instead of private to be overridden.
The ability to create a custom sink through extending SeqSink and overriding postToLogger.
Change the storage key name to be based on the toString method.
Add APISink that takes headers to be used for any custom logging
