### PR TITLE
Fixed BatchedSink issue when clearing durable store after emit

### DIFF
--- a/src/batchedSink.ts
+++ b/src/batchedSink.ts
@@ -120,11 +120,11 @@ export class BatchedSink implements Sink {
         if (this.batchedEvents.length) {
             const processEvents = this.batchedEvents.slice(0);
             this.batchedEvents.length = 0;
+            const previousBatchKey = this.batchKey;
             const emitPromise = this.emitCore(processEvents);
             (emitPromise instanceof Promise ? emitPromise : Promise.resolve())
                 .then(() => {
                     if (this.options.durableStore) {
-                        const previousBatchKey = this.batchKey;
                         return this.options.durableStore.removeItem(previousBatchKey);
                     }
                 })


### PR DESCRIPTION
At the moment, there is an issue in the Batched sink where if the inner sink emits asynchronously, the durableStore key to remove is updated before the inner sink promise resolves. This results in the durableStore to never cleanup the emitted logs.